### PR TITLE
Development

### DIFF
--- a/CppRandomAccessReflectionLib/Json.h
+++ b/CppRandomAccessReflectionLib/Json.h
@@ -14,6 +14,7 @@ namespace Json {
     template <size_t indentLevel, const char* indent = twoSpaces>
     std::ostream & operator<<(std::ostream & os, const Indent<indentLevel, indent>)
     {
+        #pragma warning(suppress: 6294) // I'll-defined loop warning when indentLevel is 0
         for ( size_t i=0; i<indentLevel; i++ )
             os << indent;
 

--- a/CppRandomAccessReflectionTest/AcceleratorsTest.cpp
+++ b/CppRandomAccessReflectionTest/AcceleratorsTest.cpp
@@ -20,7 +20,7 @@ struct Obj
     float second;
 };
 
-TEST(ReflectTest, ForPrimitive)
+TEST(AcceleratorsTest, ForPrimitive)
 {
     int intValue = 0;
     int* intPointer = &intValue;
@@ -51,7 +51,7 @@ TEST(ReflectTest, ForPrimitive)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForObject)
+TEST(AcceleratorsTest, ForObject)
 {
     Obj objValue = {1, 2.2f};
     Obj* objPointerValue = &objValue;
@@ -82,7 +82,7 @@ TEST(ReflectTest, ForObject)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForPrimitives)
+TEST(AcceleratorsTest, ForPrimitives)
 {
     constexpr size_t arraySize = 3;
     using IntArray = int[arraySize];
@@ -173,7 +173,7 @@ TEST(ReflectTest, ForPrimitives)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForPrimitivesConst)
+TEST(AcceleratorsTest, ForPrimitivesConst)
 {
     constexpr size_t arraySize = 3;
     using IntArray = int[arraySize];
@@ -276,7 +276,7 @@ TEST(ReflectTest, ForPrimitivesConst)
     EXPECT_EQ(3, timesVisited);
 }
 
-TEST(ReflectTest, ForObjects)
+TEST(AcceleratorsTest, ForObjects)
 {
     constexpr size_t arraySize = 3;
     using ObjArray = Obj[arraySize];
@@ -367,7 +367,7 @@ TEST(ReflectTest, ForObjects)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForObjectsConst)
+TEST(AcceleratorsTest, ForObjectsConst)
 {
     constexpr size_t arraySize = 3;
     using ObjArray = Obj[arraySize];
@@ -471,7 +471,7 @@ TEST(ReflectTest, ForObjectsConst)
     EXPECT_EQ(3, timesVisited);
 }
 
-TEST(ReflectTest, ForPrimitivePairs)
+TEST(AcceleratorsTest, ForPrimitivePairs)
 {
     int intValue = 0;
     std::vector<std::pair<int, float>> intToFloatVectorValue = { { 20, 20.1f }, { 30, 30.1f }, { 40, 40.1f } };
@@ -540,7 +540,7 @@ TEST(ReflectTest, ForPrimitivePairs)
     EXPECT_EQ(3, timesVisited);
 }
 
-TEST(ReflectTest, ForObjectPairs)
+TEST(AcceleratorsTest, ForObjectPairs)
 {
     Obj objValue = { 0, 0.1f };
     std::vector<std::pair<int, Obj>> intToObjVectorValue = { { 20, { 21, 20.1f } }, { 30, { 31, 30.1f } }, { 40, { 41, 40.1f } } };
@@ -609,7 +609,7 @@ TEST(ReflectTest, ForObjectPairs)
     EXPECT_EQ(3, timesVisited);
 }
 
-TEST(ReflectTest, ForPrimitivePointers)
+TEST(AcceleratorsTest, ForPrimitivePointers)
 {
     constexpr size_t arraySize = 3;
     using IntArray = int[arraySize];
@@ -702,7 +702,7 @@ TEST(ReflectTest, ForPrimitivePointers)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForPrimitivePointersConst)
+TEST(AcceleratorsTest, ForPrimitivePointersConst)
 {
     constexpr size_t arraySize = 3;
     using IntArray = int[arraySize];
@@ -807,7 +807,7 @@ TEST(ReflectTest, ForPrimitivePointersConst)
     EXPECT_EQ(3, timesVisited);
 }
 
-TEST(ReflectTest, ForObjectPointers)
+TEST(AcceleratorsTest, ForObjectPointers)
 {
     constexpr size_t arraySize = 3;
     using ObjArray = Obj[arraySize];
@@ -900,7 +900,7 @@ TEST(ReflectTest, ForObjectPointers)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForObjectPointersConst)
+TEST(AcceleratorsTest, ForObjectPointersConst)
 {
     constexpr size_t arraySize = 3;
     using ObjArray = Obj[arraySize];
@@ -1005,7 +1005,7 @@ TEST(ReflectTest, ForObjectPointersConst)
     EXPECT_EQ(0, timesVisited);
 }
 
-TEST(ReflectTest, ForPrimitivePointerPairs)
+TEST(AcceleratorsTest, ForPrimitivePointerPairs)
 {
     int intValue = 0;
     float floatValues[] = { 20.1f, 30.1f, 40.1f };
@@ -1075,7 +1075,7 @@ TEST(ReflectTest, ForPrimitivePointerPairs)
     EXPECT_EQ(3, timesVisited);
 }
 
-TEST(ReflectTest, ForObjectPointerPairs)
+TEST(AcceleratorsTest, ForObjectPointerPairs)
 {
     Obj objValue = { 0, 0.1f };
     Obj objArrayValue[] = { { 21, 20.1f }, { 31, 30.1f }, { 41, 40.1f } };

--- a/CppRandomAccessReflectionTest/ConstexprStrTest.cpp
+++ b/CppRandomAccessReflectionTest/ConstexprStrTest.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <type_traits>
 
-TEST(ReflectTest, ConstexprStrSubstr)
+TEST(ConstexprStrTest, ConstexprStrSubstr)
 {
     EXPECT_STREQ("a", ConstexprStr::substr<1>("abcdef").value);
     EXPECT_STREQ("ab", ConstexprStr::substr<2>("abcdef").value);
@@ -44,7 +44,7 @@ TEST(ReflectTest, ConstexprStrSubstr)
     EXPECT_STREQ("f", ConstexprStr::substr<1>("abcdef"+5).value);
 }
 
-TEST(ReflectTest, ConstexprStrLengthBetween)
+TEST(ConstexprStrTest, ConstexprStrLengthBetween)
 {
     EXPECT_EQ(0, ConstexprStr::length_between("<>", '<', '>'));
     EXPECT_EQ(1, ConstexprStr::length_between("<1>", '<', '>'));
@@ -59,7 +59,7 @@ TEST(ReflectTest, ConstexprStrLengthBetween)
     EXPECT_EQ(6, ConstexprStr::length_between("<<1234>>", '<', '>'));
 }
 
-TEST(ReflectTest, ConstexprStrLengthAfterLast)
+TEST(ConstexprStrTest, ConstexprStrLengthAfterLast)
 {
     EXPECT_EQ(0, ConstexprStr::length_after_last("a b ", ' '));
     EXPECT_EQ(1, ConstexprStr::length_after_last("a b 1", ' '));
@@ -67,7 +67,7 @@ TEST(ReflectTest, ConstexprStrLengthAfterLast)
     EXPECT_EQ(3, ConstexprStr::length_after_last("a b 123", ' '));
 }
 
-TEST(ReflectTest, ConstexprStrFind)
+TEST(ConstexprStrTest, ConstexprStrFind)
 {
     EXPECT_EQ(0, ConstexprStr::find("abcdefabcdef", 'a'));
     EXPECT_EQ(1, ConstexprStr::find("abcdefabcdef", 'b'));
@@ -77,7 +77,7 @@ TEST(ReflectTest, ConstexprStrFind)
     EXPECT_EQ(5, ConstexprStr::find("abcdefabcdef", 'f'));
 }
 
-TEST(ReflectTest, ConstexprStrFindLastOf)
+TEST(ConstexprStrTest, ConstexprStrFindLastOf)
 {
     EXPECT_EQ(6, ConstexprStr::find_last_of("abcdefabcdef", 'a'));
     EXPECT_EQ(7, ConstexprStr::find_last_of("abcdefabcdef", 'b'));

--- a/CppRandomAccessReflectionTest/CppRandomAccessReflectionTest.vcxproj
+++ b/CppRandomAccessReflectionTest/CppRandomAccessReflectionTest.vcxproj
@@ -162,7 +162,7 @@
     <ClCompile Include="LambdaGuardTest_PPP_PPPA.cpp" />
     <ClCompile Include="LambdaGuardTest_PP_PPP.cpp" />
     <ClCompile Include="AcceleratorsTest.cpp" />
-    <ClCompile Include="ReflectMacroTest.cpp" />
+    <ClCompile Include="ReflectTest.cpp" />
     <ClCompile Include="ReflectionSupportTest.cpp" />
     <ClCompile Include="TestMain.cpp" />
     <ClCompile Include="JsonTest.cpp" />

--- a/CppRandomAccessReflectionTest/CppRandomAccessReflectionTest.vcxproj.filters
+++ b/CppRandomAccessReflectionTest/CppRandomAccessReflectionTest.vcxproj.filters
@@ -59,10 +59,10 @@
     <ClCompile Include="GenericMacroTest.cpp">
       <Filter>Source Files\ReflectTest</Filter>
     </ClCompile>
-    <ClCompile Include="ReflectMacroTest.cpp">
+    <ClCompile Include="ReflectionSupportTest.cpp">
       <Filter>Source Files\ReflectTest</Filter>
     </ClCompile>
-    <ClCompile Include="ReflectionSupportTest.cpp">
+    <ClCompile Include="ReflectTest.cpp">
       <Filter>Source Files\ReflectTest</Filter>
     </ClCompile>
   </ItemGroup>

--- a/CppRandomAccessReflectionTest/GenericMacroTest.cpp
+++ b/CppRandomAccessReflectionTest/GenericMacroTest.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <type_traits>
 
-TEST(ReflectTest, MacroEnumT)
+TEST(GenericMacroTest, MacroEnumT)
 {
     enum_t(TestEnum, uint16_t, {
         first = 1,
@@ -27,7 +27,7 @@ TEST(ReflectTest, MacroEnumT)
     EXPECT_EQ(TestEnum::third, 3);
 }
 
-TEST(ReflectTest, MacroCountArguments)
+TEST(GenericMacroTest, MacroCountArguments)
 {
     EXPECT_EQ(1, COUNT_ARGUMENTS(a1));
     EXPECT_EQ(2, COUNT_ARGUMENTS(a1,a2));
@@ -356,7 +356,7 @@ TEST(ReflectTest, MacroCountArguments)
         a121,a122,a123,a124,a125));
 }
 
-TEST(ReflectTest, MacroForEach)
+TEST(GenericMacroTest, MacroForEach)
 {
     std::vector<std::string> test;
 
@@ -814,7 +814,7 @@ TEST(ReflectTest, MacroForEach)
     EXPECT_EQ(125, test.size()); for ( size_t i=0; i<125; i++ ) EXPECT_STREQ(std::string("a" + std::to_string(i+1)).c_str(), test[i].c_str()); test.clear();
 }
 
-TEST(ReflectTest, MacroLhs)
+TEST(GenericMacroTest, MacroLhs)
 {
     bool lhs = false;
     bool rhs = true;
@@ -822,20 +822,10 @@ TEST(ReflectTest, MacroLhs)
     EXPECT_EQ(lhs, lhsResult);
 }
 
-TEST(ReflectTest, MacroRhs)
+TEST(GenericMacroTest, MacroRhs)
 {
     bool lhs = false;
     bool rhs = true;
     bool rhsResult = RHS((lhs) rhs);
     EXPECT_EQ(rhs, rhsResult);
-}
-
-TEST(ReflectTest, BasicType)
-{
-    EXPECT_FALSE(Reflect::B::reflected);
-}
-
-TEST(ReflectTest, ReflectedType)
-{
-    EXPECT_TRUE(Reflect::R::reflected);
 }

--- a/CppRandomAccessReflectionTest/ReflectionSupportTest.cpp
+++ b/CppRandomAccessReflectionTest/ReflectionSupportTest.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <type_traits>
 
-TEST(ReflectTest, TypeToStr)
+TEST(ReflectionSupportTest, TypeToStr)
 {
     EXPECT_STREQ("int", RfS::TypeToStr<int>::Get().value);
 
@@ -31,7 +31,7 @@ TEST(ReflectTest, TypeToStr)
     EXPECT_TRUE(mapStr.find("map<int,int") != std::string::npos);
 }
 
-TEST(ReflectTest, IsPointable)
+TEST(ReflectionSupportTest, IsPointable)
 {
     EXPECT_FALSE(RfS::is_pointable<int>::value);
     EXPECT_FALSE(RfS::is_pointable<int[2]>::value);
@@ -40,7 +40,7 @@ TEST(ReflectTest, IsPointable)
     EXPECT_TRUE(RfS::is_pointable<std::unique_ptr<int>>::value);
 }
 
-TEST(ReflectTest, RemovePointer)
+TEST(ReflectionSupportTest, RemovePointer)
 {
     bool isEqual = std::is_same<int, RfS::remove_pointer<int>::type>::value;
     EXPECT_TRUE(isEqual);
@@ -54,7 +54,7 @@ TEST(ReflectTest, RemovePointer)
     EXPECT_TRUE(isEqual);
 }
 
-TEST(ReflectTest, IsStlIterable)
+TEST(ReflectionSupportTest, IsStlIterable)
 {
     EXPECT_FALSE(RfS::is_stl_iterable<int>::value);
     EXPECT_FALSE(RfS::is_stl_iterable<int*>::value);
@@ -84,7 +84,7 @@ TEST(ReflectTest, IsStlIterable)
     EXPECT_TRUE(RfS::is_stl_iterable<ExampleUnorderedMultiMapType>::value);
 }
 
-TEST(ReflectTest, IsAdaptor)
+TEST(ReflectionSupportTest, IsAdaptor)
 {
     EXPECT_FALSE(RfS::is_adaptor<int>::value);
     EXPECT_FALSE(RfS::is_adaptor<std::vector<int>>::value);
@@ -93,7 +93,7 @@ TEST(ReflectTest, IsAdaptor)
     EXPECT_TRUE(RfS::is_adaptor<std::priority_queue<int>>::value);
 }
 
-TEST(ReflectTest, ContainsPointables)
+TEST(ReflectionSupportTest, ContainsPointables)
 {
     EXPECT_FALSE(RfS::contains_pointables<int>::value);
     EXPECT_FALSE(RfS::contains_pointables<int[2]>::value);
@@ -120,7 +120,7 @@ TEST(ReflectTest, ContainsPointables)
     EXPECT_TRUE(RfS::contains_pointables<std::set<std::unique_ptr<int>>>::value);
 }
 
-TEST(ReflectTest, ElementType)
+TEST(ReflectionSupportTest, ElementType)
 {
     bool isEqual = std::is_same<void, RfS::element_type<int>::type>::value;
     EXPECT_TRUE(isEqual);
@@ -132,7 +132,7 @@ TEST(ReflectTest, ElementType)
     EXPECT_TRUE(isEqual);
 }
 
-TEST(ReflectTest, KeyType)
+TEST(ReflectionSupportTest, KeyType)
 {
     bool isEqual = std::is_same<void, RfS::key_type<int>::type>::value;
     EXPECT_TRUE(isEqual);
@@ -155,7 +155,7 @@ TEST(ReflectTest, KeyType)
     EXPECT_TRUE(isEqual);
 }
 
-TEST(ReflectTest, ContainsPairs)
+TEST(ReflectionSupportTest, ContainsPairs)
 {
     using IntPair = std::pair<int, int>;
     EXPECT_FALSE(RfS::contains_pairs<int>::value);
@@ -172,7 +172,7 @@ TEST(ReflectTest, ContainsPairs)
     EXPECT_TRUE(RfS::contains_pairs<ExampleMultiMapType>::value);
 }
 
-TEST(ReflectTest, GetUnderlyingContainer)
+TEST(ReflectionSupportTest, GetUnderlyingContainer)
 {
     // Stacks
     std::stack<int> defaultStack;
@@ -277,7 +277,7 @@ void IfConditionTest(Function function)
     RfS::ConditionalCall<condition, Function>::call(function);
 }
 
-TEST(ReflectTest, ConditionalCall)
+TEST(ReflectionSupportTest, ConditionalCall)
 {
     bool value = false;
     IfConditionTest<false>([&](auto) {
@@ -290,7 +290,7 @@ TEST(ReflectTest, ConditionalCall)
     EXPECT_TRUE(value);
 }
 
-TEST(ReflectTest, FieldSimple)
+TEST(ReflectionSupportTest, FieldSimple)
 {
     size_t fieldIndex = 0;
     char fieldName[] = "fieldName";
@@ -311,7 +311,7 @@ TEST(ReflectTest, FieldSimple)
     EXPECT_EQ(fieldIsReflected, field.isReflected);
 }
 
-TEST(ReflectTest, FieldTemplated)
+TEST(ReflectionSupportTest, FieldTemplated)
 {
     size_t fieldIndex = 0;
     char fieldName[] = "fieldName";

--- a/GoogleTestLib/googletest/googletest/include/gtest/gtest-test-part.h
+++ b/GoogleTestLib/googletest/googletest/include/gtest/gtest-test-part.h
@@ -57,6 +57,8 @@ class GTEST_API_ TestPartResult {
   // C'tor.  TestPartResult does NOT have a default constructor.
   // Always use this constructor (with parameters) to create a
   // TestPartResult object.
+  
+  #pragma warning(suppress: 26812) // Suppress warnings from used library
   TestPartResult(Type a_type,
                  const char* a_file_name,
                  int a_line_number,

--- a/GoogleTestLib/googletest/googletest/include/gtest/gtest.h
+++ b/GoogleTestLib/googletest/googletest/include/gtest/gtest.h
@@ -1472,6 +1472,7 @@ class EqHelper<true> {
   // version will be picked when the second argument to ASSERT_EQ() is
   // NOT a pointer, e.g. ASSERT_EQ(0, AnIntFunction()) or
   // EXPECT_EQ(false, a_bool).
+  #pragma warning(suppress: 26812) // Suppress warnings from used library
   template <typename T1, typename T2>
   static AssertionResult Compare(
       const char* lhs_expression,

--- a/GoogleTestLib/googletest/googletest/include/gtest/internal/gtest-port.h
+++ b/GoogleTestLib/googletest/googletest/include/gtest/internal/gtest-port.h
@@ -1731,6 +1731,7 @@ class GTEST_API_ Mutex {
   // This constructor intentionally does nothing.  It relies on type_ being
   // statically initialized to 0 (effectively setting it to kStatic) and on
   // ThreadSafeLazyInit() to lazily initialize the rest of the members.
+  #pragma warning(suppress: 26495 26812) // Suppress warnings from used library
   explicit Mutex(StaticConstructorSelector /*dummy*/) {}
 
   Mutex();


### PR DESCRIPTION
- Implement inheritance reflection Fixes #13 
- Suppress or fix all remaining warnings
- Add TypeToStr method to reflect namespace
- Separate out unit test categories for Reflect code